### PR TITLE
Add usedBedsHospital and usedBedsIcu

### DIFF
--- a/src/Chart.js
+++ b/src/Chart.js
@@ -58,6 +58,7 @@ export default class Chart extends PureComponent {
   }
 
   render() {
+    const { usedBedsHospital, usedBedsIcu } = this.props;
     const bedData = this.generateData();
     const reducer = (accumulator, currentValue) => accumulator + currentValue.hospital;
     const totalHospital = bedData.reduce(reducer, 0);
@@ -82,8 +83,8 @@ export default class Chart extends PureComponent {
             allowDecimals={false}
           />
           <Tooltip />
-          <ReferenceLine y={900000} label="All Beds" stroke="red" strokeDasharray="3 3" />
-          <ReferenceLine y={90000} label="ICU Beds" stroke="red" strokeDasharray="3 3" />
+          <ReferenceLine y={900000 - usedBedsHospital - usedBedsIcu} label="All Beds" stroke="red" strokeDasharray="3 3" />
+          <ReferenceLine y={90000 - usedBedsIcu} label="ICU Beds" stroke="red" strokeDasharray="3 3" />
           <Area type="monotone" dataKey="hospital" stackId="1" stroke="#8884d8" fill="#8884d8" />
           <Area type="monotone" dataKey="icu" stackId="2" stroke="#82ca9d" fill="#82ca9d" />
         </AreaChart>

--- a/src/Controls.js
+++ b/src/Controls.js
@@ -6,6 +6,8 @@ export default class Controls extends Component {
   constructor() {
     /* 1. Initialize Ref */
     super(); 
+    this.usedBedsHospital = React.createRef();
+    this.usedBedsIcu = React.createRef();
     this.lengthOfOutbreak = React.createRef();
     this.infectionRate = React.createRef();
     this.hospitalRate = React.createRef();
@@ -13,6 +15,16 @@ export default class Controls extends Component {
     this.fatalityRate = React.createRef();
     this.hospitalStayLength = React.createRef();
     this.icuStayLength = React.createRef();
+ }
+
+ handleUsedBedsHospitalChange() {
+  const value = Number(this.usedBedsHospital.current.value)
+  this.props.updateUsedBedsHospital(value)
+ }
+
+ handleUsedBedsIcuChange() {
+  const value = Number(this.usedBedsIcu.current.value)
+  this.props.updateUsedBedsIcu(value)
  }
 
  handleLengthOfOutbreakChange() {
@@ -53,6 +65,32 @@ handleIcuStayLengthChange() {
  render() {   
     return (
       <div style={{ width: '30rem' }}>
+        <InputGroup className="mb-3">
+          <FormControl
+            ref={this.usedBedsHospital}
+            defaultValue={Defaults.usedBedsHospital}
+            onChange={() => this.handleUsedBedsHospitalChange()}
+            aria-label="Default"
+            aria-describedby="inputGroup-sizing-default"
+          />
+          <InputGroup.Append>
+            <InputGroup.Text id="inputGroup-sizing-default">Beds in Use (Hospital)</InputGroup.Text>
+          </InputGroup.Append>
+        </InputGroup>
+        
+        <InputGroup className="mb-3">
+          <FormControl
+            ref={this.usedBedsIcu}
+            defaultValue={Defaults.usedBedsIcu}
+            onChange={() => this.handleUsedBedsIcuChange()}
+            aria-label="Default"
+            aria-describedby="inputGroup-sizing-default"
+          />
+          <InputGroup.Append>
+            <InputGroup.Text id="inputGroup-sizing-default">Beds in Use (ICU)</InputGroup.Text>
+          </InputGroup.Append>
+        </InputGroup>
+        
         <InputGroup className="mb-3">
           <FormControl
             ref={this.lengthOfOutbreak}

--- a/src/Defaults.js
+++ b/src/Defaults.js
@@ -1,4 +1,6 @@
 export default {
+  usedBedsHospital: 0,
+  usedBedsIcu: 0,
   lengthOfOutbreak: 365,
   infectionRate: 10,
   hospitalRate: 20,

--- a/src/MainPanel.js
+++ b/src/MainPanel.js
@@ -13,6 +13,14 @@ export default class MainPanel extends Component {
     this.population = 327000000.0
   }
 
+  updateUsedBedsHospital = (value) => {
+    this.setState({ usedBedsHospital: value })
+  }
+
+  updateUsedBedsIcu = (value) => {
+    this.setState({ usedBedsIcu: value })
+  }
+
   updateLengthOfOutbreak = (value) => {
     this.setState({ lengthOfOutbreak: value })
   }
@@ -65,7 +73,7 @@ export default class MainPanel extends Component {
   }
 
   render() {
-    const { lengthOfOutbreak, hospitalStayLength, icuStayLength } = this.state;
+    const { usedBedsHospital, usedBedsIcu, lengthOfOutbreak, hospitalStayLength, icuStayLength } = this.state;
     const hospitalRate = this.state.hospitalRate / 100
     const icuRate = this.state.icuRate / 100
 
@@ -83,6 +91,8 @@ export default class MainPanel extends Component {
             height="100%"
           >
             <Chart
+              usedBedsHospital={usedBedsHospital}
+              usedBedsIcu={usedBedsIcu}
               lengthOfOutbreak={lengthOfOutbreak}
               infections={this.infections()}
               hospitalRate={hospitalRate}
@@ -104,6 +114,8 @@ export default class MainPanel extends Component {
           </Figure>
           <Figure>
             <Controls 
+              updateUsedBedsHospital={this.updateUsedBedsHospital}
+              updateUsedBedsIcu={this.updateUsedBedsIcu}
               updateLengthOfOutbreak={this.updateLengthOfOutbreak}
               updateInfectionRate={this.updateInfectionRate}
               updateHospitalRate={this.updateHospitalRate}


### PR DESCRIPTION
Hi -- I really like the hospital capacity idea.  React is way outside my wheel house but I thought I'd try to take a crack at lending a hand.  

I tried adding a super rudimentary 'current utilization rate' that you mentioned in a tweet:

["1. It doesn't yet account for current utilization rates, & assumes all AHA staffed beds are empty. Obvs that has to be fixed."](https://twitter.com/jonst0kes/status/1236163396007079941?s=20)

Added `usedBedsHospital` & `usedBedsIcu` which are subtracted from the 'All Beds' and 'ICU Beds' lines in the chart.